### PR TITLE
Added collision callbacks to physics system and redid body creation process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,8 @@ add_executable(MiniGameEngine
     Physics/Physics.cpp
     Physics/PhysicsDebug.hpp
     Physics/PhysicsDebug.cpp
+    Physics/CollisionCallback.hpp
+    Physics/CollisionCallback.cpp
     )
 
 target_link_libraries(MiniGameEngine  PRIVATE LuaBridge SDL2_image SDL2_ttf SDL2_gfx lua dl fmt::fmt Box2D ${SDL2_LIBRARIES} ${SDL2_IMAGE_LIBRARIES})

--- a/Physics/ColliderShape.hpp
+++ b/Physics/ColliderShape.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <Box2D/Box2D.h>
-#include "PhysicsWorld.hpp"
 #include "../Lua/LuaMachine.hpp"
 
 /// @brief Base class for all collision shapes

--- a/Physics/CollisionCallback.cpp
+++ b/Physics/CollisionCallback.cpp
@@ -1,0 +1,49 @@
+#include "CollisionCallback.hpp"
+
+void CollisionCallback::BeginContact(b2Contact *contact)
+{
+    void *mainBodyData = contact->GetFixtureA()->GetBody()->GetUserData();
+    void *otherBodyData = contact->GetFixtureB()->GetBody()->GetUserData();
+    PhysicsBody *mainBody = nullptr;
+    PhysicsBody *otherBody = nullptr;
+    if (mainBodyData != nullptr)
+    {
+        mainBody = static_cast<PhysicsBody *>(mainBodyData);
+    }
+    if (otherBodyData != nullptr)
+    {
+        otherBody = static_cast<PhysicsBody *>(otherBodyData);
+    }
+    if (mainBodyData != nullptr)
+    {
+        mainBody->BeginContact(otherBody);
+    }
+    if (otherBodyData != nullptr)
+    {
+        otherBody->BeginContact(mainBody);
+    }
+}
+
+void CollisionCallback::EndContact(b2Contact *contact)
+{
+    void *mainBodyData = contact->GetFixtureA()->GetBody()->GetUserData();
+    void *otherBodyData = contact->GetFixtureB()->GetBody()->GetUserData();
+    PhysicsBody *mainBody = nullptr;
+    PhysicsBody *otherBody = nullptr;
+    if (mainBodyData != nullptr)
+    {
+        mainBody = static_cast<PhysicsBody *>(mainBodyData);
+    }
+    if (otherBodyData != nullptr)
+    {
+        otherBody = static_cast<PhysicsBody *>(otherBodyData);
+    }
+    if (mainBodyData != nullptr)
+    {
+        mainBody->EndContact(otherBody);
+    }
+    if (otherBodyData != nullptr)
+    {
+        otherBody->EndContact(mainBody);
+    }
+}

--- a/Physics/CollisionCallback.hpp
+++ b/Physics/CollisionCallback.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include "PhysicsBody.hpp"
+
+/// @brief Class for handling contacts between objects
+class CollisionCallback : b2ContactListener
+{
+public:
+    void BeginContact(b2Contact *contact) override;
+    void EndContact(b2Contact *contact) override;
+};

--- a/Physics/PhysicsBody.cpp
+++ b/Physics/PhysicsBody.cpp
@@ -11,7 +11,9 @@ void PhysicsBody::bindLua(lua_State *state)
         .addProperty("velocity", &PhysicsBody::getVelocity, &PhysicsBody::setVelocity)
         .addProperty("on_collision_begin", &PhysicsBody::m_contactBeginCallback)
         .addProperty("on_collision_end", &PhysicsBody::m_contactEndCallback)
-        .addConstructor<void (*)(PhysicsWorld *, Vector2, ColliderShape const &, int, luabridge::LuaRef, luabridge::LuaRef)>()
+        .addProperty("data", &PhysicsBody::m_data)
+        .addProperty("active", &PhysicsBody::getIsActive,&PhysicsBody::setIsActive)
+        .addConstructor<void (*)(PhysicsWorld *, Vector2, ColliderShape const &, int, luabridge::LuaRef, luabridge::LuaRef, luabridge::LuaRef)>()
         .endClass()
         .endNamespace();
 }

--- a/Physics/PhysicsBody.cpp
+++ b/Physics/PhysicsBody.cpp
@@ -9,7 +9,9 @@ void PhysicsBody::bindLua(lua_State *state)
         .addFunction("get_position", &PhysicsBody::getPosition)
         .addFunction("get_rotation", &PhysicsBody::getRotation)
         .addProperty("velocity", &PhysicsBody::getVelocity, &PhysicsBody::setVelocity)
-        .addConstructor<void (*)(PhysicsWorld *, Vector2, ColliderShape const &, int)>()
+        .addProperty("on_collision_begin", &PhysicsBody::m_contactBeginCallback)
+        .addProperty("on_collision_end", &PhysicsBody::m_contactEndCallback)
+        .addConstructor<void (*)(PhysicsWorld *, Vector2, ColliderShape const &, int, luabridge::LuaRef, luabridge::LuaRef)>()
         .endClass()
         .endNamespace();
 }
@@ -28,7 +30,23 @@ Vector2 PhysicsBody::getVelocity() const
     return Vector2(m_body->GetLinearVelocity().x, m_body->GetLinearVelocity().y);
 }
 
-void PhysicsBody::setVelocity(Vector2 const& velocity)
+void PhysicsBody::setVelocity(Vector2 const &velocity)
 {
     m_body->SetLinearVelocity(b2Vec2(velocity.x, velocity.y));
+}
+
+void PhysicsBody::BeginContact(PhysicsBody *other)
+{
+    if (!m_contactBeginCallback.isNil())
+    {
+        m_contactBeginCallback(this, other);
+    }
+}
+
+void PhysicsBody::EndContact(PhysicsBody *other)
+{
+    if (!m_contactEndCallback.isNil())
+    {
+        m_contactEndCallback(this, other);
+    }
 }

--- a/Physics/PhysicsBody.hpp
+++ b/Physics/PhysicsBody.hpp
@@ -1,11 +1,19 @@
 #pragma once
 #include "PhysicsWorld.hpp"
 #include "ColliderShape.hpp"
+#include "../Lua/LuaMachine.hpp"
 
 class PhysicsBody
 {
 public:
-    PhysicsBody(PhysicsWorld *world, Vector2 position, ColliderShape const &shape, int type) : m_world(world)
+    PhysicsBody(PhysicsWorld *world,
+                Vector2 position,
+                ColliderShape const &shape,
+                int type,
+                luabridge::LuaRef contactBeginCallback,
+                luabridge::LuaRef contactEndCallback) : m_world(world),
+                                                        m_contactBeginCallback(contactBeginCallback),
+                                                        m_contactEndCallback(contactEndCallback)
     {
         b2BodyDef bodyDef;
         bodyDef.type = (b2BodyType)type;
@@ -13,6 +21,7 @@ public:
         m_body = m_world->getWorld()->CreateBody(&bodyDef);
 
         m_body->CreateFixture(shape.getFixtureDef());
+        m_body->SetUserData(this);
     }
 
     /// @brief Get current location of the body in the physics world
@@ -21,11 +30,14 @@ public:
 
     Vector2 getVelocity() const;
 
-    void setVelocity(Vector2 const& velocity);
+    void setVelocity(Vector2 const &velocity);
 
     /// @brief Current rotation in radians
     /// @return  Current rotation in radians
     float getRotation() const;
+
+    void BeginContact(PhysicsBody *other);
+    void EndContact(PhysicsBody *other);
 
     ~PhysicsBody()
     {
@@ -37,4 +49,6 @@ public:
 private:
     PhysicsWorld *m_world;
     b2Body *m_body;
+    luabridge::LuaRef m_contactBeginCallback;
+    luabridge::LuaRef m_contactEndCallback;
 };

--- a/Physics/PhysicsBody.hpp
+++ b/Physics/PhysicsBody.hpp
@@ -3,6 +3,7 @@
 #include "ColliderShape.hpp"
 #include "../Lua/LuaMachine.hpp"
 
+/// @brief Class that represents a body in a physical world
 class PhysicsBody
 {
 public:
@@ -11,9 +12,11 @@ public:
                 ColliderShape const &shape,
                 int type,
                 luabridge::LuaRef contactBeginCallback,
-                luabridge::LuaRef contactEndCallback) : m_world(world),
-                                                        m_contactBeginCallback(contactBeginCallback),
-                                                        m_contactEndCallback(contactEndCallback)
+                luabridge::LuaRef contactEndCallback,
+                luabridge::LuaRef data) : m_world(world),
+                                          m_contactBeginCallback(contactBeginCallback),
+                                          m_contactEndCallback(contactEndCallback),
+                                          m_data(data)
     {
         b2BodyDef bodyDef;
         bodyDef.type = (b2BodyType)type;
@@ -36,8 +39,21 @@ public:
     /// @return  Current rotation in radians
     float getRotation() const;
 
+    /// @brief Called when contact between this and other body happens
+    /// @param other Body with which this body collided
     void BeginContact(PhysicsBody *other);
+
+    /// @brief Called when contact between this and other body end
+    /// @param other Body with which this body collided
     void EndContact(PhysicsBody *other);
+
+    /// @brief Sets body to inactive
+    void setIsActive(bool active)
+    {
+        m_body->SetActive(active);
+    }
+
+    bool getIsActive() const { return m_body->IsActive(); }
 
     ~PhysicsBody()
     {
@@ -51,4 +67,5 @@ private:
     b2Body *m_body;
     luabridge::LuaRef m_contactBeginCallback;
     luabridge::LuaRef m_contactEndCallback;
+    luabridge::LuaRef m_data;
 };

--- a/Physics/PhysicsWorld.cpp
+++ b/Physics/PhysicsWorld.cpp
@@ -1,4 +1,6 @@
 #include "PhysicsWorld.hpp"
+#include "../Log.hpp"
+#include <algorithm>
 
 b2Vec2 PhysicsHelpers::fromVector2(Vector2 const &vec) { return b2Vec2(vec.x, vec.y); }
 
@@ -8,13 +10,50 @@ void PhysicsWorld::bindLua(lua_State *state)
         .beginNamespace("Physics")
         .beginClass<PhysicsWorld>("World")
         .addProperty("gravity", &PhysicsWorld::getGravity, &PhysicsWorld::setGravity)
+        .addFunction("create_body", &PhysicsWorld::createBody)
         .endClass()
         .endNamespace();
+}
+
+void PhysicsWorld::freeBodies()
+{
+    if (m_world->IsLocked())
+    {
+        Log::error("Attempted to perform body destruction while world was locked");
+        return;
+    }
+    for (b2Body *body : m_deadBodies)
+    {
+        m_world->DestroyBody(body);
+    }
+    m_deadBodies.clear();
+}
+
+PhysicsBody *PhysicsWorld::createBody(Vector2 position, ColliderShape const &shape, int32_t type, luabridge::LuaRef contactBeginCallback, luabridge::LuaRef contactEndCallback, luabridge::LuaRef data)
+{
+    PhysicsBody *body = new PhysicsBody(this, position, shape, type, contactBeginCallback, contactEndCallback, data);
+    m_bodies.push_back(body);
+    return body;
+}
+
+void PhysicsWorld::destroyBody(PhysicsBody *body)
+{
+    m_deadBodies.push_back(body->getBody());
+    if (std::vector<PhysicsBody *>::iterator it = std::find(m_bodies.begin(), m_bodies.end(), body);
+        it != m_bodies.end())
+    {
+        m_bodies.erase(it);
+    }
 }
 
 void PhysicsWorld::step(float32 timeStep)
 {
     m_world->Step(timeStep, m_velocityIterCount, m_positionIterCount);
+    freeBodies();
+    for (PhysicsBody *body : m_bodies)
+    {
+        body->update();
+    }
 }
 
 void PhysicsWorld::setDebugDraw(b2Draw *debug)

--- a/Physics/PhysicsWorld.hpp
+++ b/Physics/PhysicsWorld.hpp
@@ -11,9 +11,10 @@ namespace PhysicsHelpers
 class PhysicsWorld
 {
 public:
-    PhysicsWorld(Vector2 gravity)
+    PhysicsWorld(Vector2 gravity, b2ContactListener *contactListener)
     {
         m_world = std::make_unique<b2World>(PhysicsHelpers::fromVector2(gravity));
+        m_world->SetContactListener(contactListener);
     }
 
     /// @brief Call physics update fuctions

--- a/Physics/PhysicsWorld.hpp
+++ b/Physics/PhysicsWorld.hpp
@@ -2,12 +2,47 @@
 #include <Box2D/Box2D.h>
 #include <memory>
 #include "../Graphics/Vector.hpp"
+#include "../Lua/LuaMachine.hpp"
+#include "PhysicsBody.hpp"
+
+class PhysicsWorldException : public std::exception
+{
+public:
+    /// @brief Create an exception
+    /// @param message Message as c string
+    explicit PhysicsWorldException(const char *message)
+        : m_msg(message) {}
+
+    /// @brief Create an exception
+    /// @param message Message as c++ string
+    explicit PhysicsWorldException(const std::string &message)
+        : m_msg(message) {}
+
+    /** Destructor.
+     * Virtual to allow for subclassing.
+     */
+    virtual ~PhysicsWorldException() noexcept {}
+
+    /** Returns a pointer to the (constant) error description.
+     *  @return A pointer to a const char*. The underlying memory
+     *          is in posession of the Exception object. Callers must
+     *          not attempt to free the memory.
+     */
+    virtual const char *what() const noexcept
+    {
+        return m_msg.c_str();
+    }
+
+protected:
+    std::string m_msg;
+};
 
 namespace PhysicsHelpers
 {
     b2Vec2 fromVector2(Vector2 const &vec);
 }
 
+/// @brief Wrapper around Box2D world. Simulates physics itself and manages all of the object in the physics world
 class PhysicsWorld
 {
 public:
@@ -29,13 +64,36 @@ public:
 
     Vector2 getGravity() const;
 
+    /// @brief Returns scale world to pixel scale, value is same as PHYSICS_SCALE macro defined in project
+    /// @return
     float getWorldScale() const { return m_worldScale; }
 
     void setDebugDraw(b2Draw *debug);
 
     static void bindLua(lua_State *state);
 
+    /// @brief Safely destroys body object. Because box2d manages all bodies,
+    /// instead of freeing memory manually using  delete or free(), memory allocated for the body will be freed by the world
+    /// @param body Body to destroy
+    void destroyBody(PhysicsBody *body);
+
+    /// @brief Creates a new body using PhysicsBody constructor and registers it into the world for update notification
+    /// @param position Where will the body be spawned
+    /// @param shape Shape of the body
+    /// @param type Type of the body. See PhysicsBody::Type enum
+    /// @param contactBeginCallback Lua function that will be called when this body collides
+    /// @param contactEndCallback Lua function that will be called when this body ends collision
+    /// @param data Any user data that might need to stored. For example: reference to object that owns the body
+    PhysicsBody *createBody(Vector2 position, ColliderShape const &shape, int32_t type, luabridge::LuaRef contactBeginCallback, luabridge::LuaRef contactEndCallback, luabridge::LuaRef data);
+
 private:
+    /// @brief Performs destruction of all bodies marked as "dead"
+    void freeBodies();
+    /// @brief Collection of bodies that should be deleted at the end of the frame
+    std::vector<b2Body *> m_deadBodies;
+
+    std::vector<PhysicsBody *> m_bodies;
+
     std::unique_ptr<b2World> m_world;
     int32_t m_velocityIterCount = 6;
     int32_t m_positionIterCount = 2;

--- a/Window.hpp
+++ b/Window.hpp
@@ -18,6 +18,7 @@
 #include "System/Input.hpp"
 #include "Content/ContentManager.hpp"
 #include "Physics/Physics.hpp"
+#include "Physics/CollisionCallback.hpp"
 #include "Physics/PhysicsDebug.hpp"
 
 /// @brief Class that handles SDL window and communication between parts of software
@@ -29,7 +30,7 @@ public:
     Window(int32_t width, int32_t height) : m_width(width),
                                             m_height(height),
                                             m_running(true),
-                                            m_world(Vector2(0, 9.8f))
+                                            m_world(Vector2(0, 9.8f), (b2ContactListener*)&m_collisionManager)
 
     {
         m_window = SDL_CreateWindow("Nema-Video v0.0.1", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
@@ -88,6 +89,7 @@ private:
     ContentManager m_manager;
     PhysicsWorld m_world;
     PhysicsDebugDraw *m_physicsDebug;
+    CollisionCallback m_collisionManager;
     /// @brief Amount of time passed since last frame. Default value is just random non zero value
     float m_delta = 0.000717;
     /// @brief Clock fo storing last time when update happened


### PR DESCRIPTION
Added collision callbacks and user data to bodies via `LuaRef` objects.
Bodies are now created via `PhysicsWorld:create_body` instead of body constructor for both convenience  and safer value updates in bodies